### PR TITLE
Revert "Remove libbfqio"

### DIFF
--- a/libbfqio/Android.bp
+++ b/libbfqio/Android.bp
@@ -1,0 +1,44 @@
+//
+// Copyright (C) 2017-2019 The LineageOS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+cc_library_headers {
+    name: "libbfqio_headers",
+    vendor_available: true,
+    export_include_dirs: ["include"],
+}
+
+cc_library {
+    name: "libbfqio",
+    vendor_available: true,
+    srcs: [
+        "bfqio.c",
+    ],
+
+    shared_libs: [
+        "libcutils",
+        "liblog",
+    ],
+    header_libs: [
+        "libbfqio_headers",
+    ],
+    export_header_lib_headers: ["libbfqio_headers"],
+
+    cflags: [
+        "-Werror",
+        "-Wall",
+        "-Wextra",
+    ],
+}

--- a/libbfqio/bfqio.c
+++ b/libbfqio/bfqio.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "bfqio"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <cutils/iosched_policy.h>
+#include <log/log.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int __rtio_cgroup_supported = -1;
+static pthread_once_t __rtio_init_once = PTHREAD_ONCE_INIT;
+
+static void __initialize_rtio(void) {
+    if (!access("/dev/bfqio/tasks", W_OK) || !access("/dev/bfqio/rt-display/tasks", W_OK)) {
+        __rtio_cgroup_supported = 1;
+    } else {
+        __rtio_cgroup_supported = 0;
+    }
+}
+
+int android_set_rt_ioprio(int tid, int rt) {
+    int fd = -1, rc = -1;
+
+    pthread_once(&__rtio_init_once, __initialize_rtio);
+    if (__rtio_cgroup_supported != 1) {
+        return -1;
+    }
+
+    if (rt) {
+        fd = open("/dev/bfqio/rt-display/tasks", O_WRONLY | O_CLOEXEC);
+    } else {
+        fd = open("/dev/bfqio/tasks", O_WRONLY | O_CLOEXEC);
+    }
+
+    if (fd < 0) {
+        return -1;
+    }
+
+#ifdef HAVE_GETTID
+    if (tid == 0) {
+        tid = gettid();
+    }
+#endif
+
+    // specialized itoa -- works for tid > 0
+    char text[22];
+    char *end = text + sizeof(text) - 1;
+    char *ptr = end;
+    *ptr = '\0';
+    while (tid > 0) {
+        *--ptr = '0' + (tid % 10);
+        tid = tid / 10;
+    }
+
+    rc = write(fd, ptr, end - ptr);
+    if (rc < 0) {
+        /*
+         * If the thread is in the process of exiting,
+         * don't flag an error
+         */
+        if (errno == ESRCH) {
+            rc = 0;
+        } else {
+            SLOGV("android_set_rt_ioprio failed to write '%s' (%s); fd=%d\n",
+                  ptr, strerror(errno), fd);
+        }
+    }
+
+    close(fd);
+    return rc;
+}

--- a/libbfqio/include/bfqio/bfqio.h
+++ b/libbfqio/include/bfqio/bfqio.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int android_set_rt_ioprio(int pid, int rt);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This reverts commit 8f67d055b36d992f2f09aa6f733aa06ee3d5b917.

Older Devices still need this for their display hal, So reverting it is necessary.